### PR TITLE
fix: Remove REST delete so it can be added back by user

### DIFF
--- a/src/todoitems/todoitems.controller.ts
+++ b/src/todoitems/todoitems.controller.ts
@@ -53,8 +53,6 @@ export class TodoitemsController {
     return this.todoitemsService.update(id, sanitizeTodo(updateTodoitemDto));
   }
 
-  @Delete(':id')
-  remove(@Param('id') id: string) {
-    return this.todoitemsService.remove(id);
-  }
+  // INSERT DELETE CODE HERE
+
 }


### PR DESCRIPTION
I accidentally left in the REST delete code on initial commit. It's meant to be filled in later by the user, using steps in the starter guide.